### PR TITLE
Add formality support to DeepL translator

### DIFF
--- a/docs/how-to/integrations/machine-translation.md
+++ b/docs/how-to/integrations/machine-translation.md
@@ -124,11 +124,13 @@ WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
     "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
     "OPTIONS": {
         "AUTH_KEY": "<Your DeepL key here>",
-        # Optional DeepL API option
+        # Optional DeepL API option. Accepts "default", "prefer_more" or "prefer_less". For more information visit the DeepL API docs link below.
         "FORMALITY": "<Your DeepL formality preference here>",
     },
 }
 ```
+
+[DeepL API docs](https://www.deepl.com/docs-api/translate-text/)
 
 ## LibreTranslate
 

--- a/docs/how-to/integrations/machine-translation.md
+++ b/docs/how-to/integrations/machine-translation.md
@@ -124,6 +124,8 @@ WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
     "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
     "OPTIONS": {
         "AUTH_KEY": "<Your DeepL key here>",
+        # Optional DeepL API option
+        "FORMALITY": "<Your DeepL formality preference here>",
     },
 }
 ```

--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -1,8 +1,13 @@
+import warnings
+
 import requests
 
 from wagtail_localize.strings import StringValue
 
 from .base import BaseMachineTranslator
+
+
+SUPPORTED_FORMALITY_OPTIONS = {"default", "prefer_less", "prefer_more"}
 
 
 def language_code(code, is_target=False):
@@ -24,7 +29,7 @@ class DeepLTranslator(BaseMachineTranslator):
         return "https://api.deepl.com/v2/translate"
 
     def translate(self, source_locale, target_locale, strings):
-        args = {
+        parameters = {
             "auth_key": self.options["AUTH_KEY"],
             "text": [string.data for string in strings],
             "tag_handling": "xml",
@@ -33,11 +38,16 @@ class DeepLTranslator(BaseMachineTranslator):
         }
 
         if self.options.get("FORMALITY"):
-            args["formality"] = self.options["FORMALITY"]
+            if self.options["FORMALITY"] in SUPPORTED_FORMALITY_OPTIONS:
+                parameters["formality"] = self.options["FORMALITY"]
+            else:
+                warnings.warn(
+                    f"Unsupported formality option '{self.options['FORMALITY']}'. Supported options are: {', '.join(SUPPORTED_FORMALITY_OPTIONS)}"
+                )
 
         response = requests.post(
             self.get_api_endpoint(),
-            args,
+            parameters,
             timeout=30,
         )
 

--- a/wagtail_localize/machine_translators/deepl.py
+++ b/wagtail_localize/machine_translators/deepl.py
@@ -24,17 +24,20 @@ class DeepLTranslator(BaseMachineTranslator):
         return "https://api.deepl.com/v2/translate"
 
     def translate(self, source_locale, target_locale, strings):
+        args = {
+            "auth_key": self.options["AUTH_KEY"],
+            "text": [string.data for string in strings],
+            "tag_handling": "xml",
+            "source_lang": language_code(source_locale.language_code),
+            "target_lang": language_code(target_locale.language_code, is_target=True),
+        }
+
+        if self.options.get("FORMALITY"):
+            args["formality"] = self.options["FORMALITY"]
+
         response = requests.post(
             self.get_api_endpoint(),
-            {
-                "auth_key": self.options["AUTH_KEY"],
-                "text": [string.data for string in strings],
-                "tag_handling": "xml",
-                "source_lang": language_code(source_locale.language_code),
-                "target_lang": language_code(
-                    target_locale.language_code, is_target=True
-                ),
-            },
+            args,
             timeout=30,
         )
 

--- a/wagtail_localize/machine_translators/tests/test_deepl_translator.py
+++ b/wagtail_localize/machine_translators/tests/test_deepl_translator.py
@@ -25,6 +25,14 @@ DEEPL_SETTINGS_WITH_FORMALITY = {
     },
 }
 
+DEEPL_SETTINGS_WITH_UNSUPPORTED_FORMALITY = {
+    "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
+    "OPTIONS": {
+        "AUTH_KEY": "asd-23-ssd-243-adsf-dummy-auth-key:bla",
+        "FORMALITY": "less",
+    },
+}
+
 
 class TestDeeplTranslator(TestCase):
     @override_settings(WAGTAILLOCALIZE_MACHINE_TRANSLATOR=DEEPL_SETTINGS_FREE_ENDPOINT)
@@ -65,6 +73,25 @@ class TestDeeplTranslator(TestCase):
         strings = [StringValue("Test string")]
 
         translator.translate(source_locale, target_locale, strings)
+
+        mock_post.assert_called_once()
+        called_args, called_kwargs = mock_post.call_args
+        self.assertNotIn("formality", called_args[1])
+
+    @override_settings(
+        WAGTAILLOCALIZE_MACHINE_TRANSLATOR=DEEPL_SETTINGS_WITH_UNSUPPORTED_FORMALITY
+    )
+    @patch("requests.post")
+    @patch("warnings.warn")
+    def test_translate_with_non_supported_formality_option(self, mock_warn, mock_post):
+        translator = get_machine_translator()
+        source_locale = Mock(language_code="en")
+        target_locale = Mock(language_code="de")
+        strings = [StringValue("Test string")]
+
+        translator.translate(source_locale, target_locale, strings)
+
+        mock_warn.assert_called_once()
 
         mock_post.assert_called_once()
         called_args, called_kwargs = mock_post.call_args


### PR DESCRIPTION
This PR adds formality support to the existing DeepL translator (https://www.deepl.com/docs-api/translate-text). This is done by specifying an optional option.